### PR TITLE
Handle stop when not running

### DIFF
--- a/endpoints/cron.py
+++ b/endpoints/cron.py
@@ -15,6 +15,10 @@ START_HTML = (
     '<html><head></head><body>Cron started. Returning in 5 seconds... <meta http-equiv="refresh" content="5;URL=./status"></body></html>',
 )
 ALREADY_STARTED_HTML = '<html><head></head><body>Cron already started. Returning in 5 seconds... <meta http-equiv="refresh" content="5;URL=./status"></body></html>'
+ALREADY_STOPPED_HTML = (
+    '<html><head></head><body>Cron was not running. Returning in 5 seconds... '
+    '<meta http-equiv="refresh" content="5;URL=./status"></body></html>'
+)
 
 
 def is_now_to_call(cron_str):
@@ -88,12 +92,19 @@ class CronEndpoint(Endpoint):
                 content_type="text/html",
             )
         elif command == "stop":
-            started_app_ids.remove(app_id)
-            return Response(
-                STOP_HTML,
-                status=200,
-                content_type="text/html",
-            )
+            if app_id in started_app_ids:
+                started_app_ids.discard(app_id)
+                return Response(
+                    STOP_HTML,
+                    status=200,
+                    content_type="text/html",
+                )
+            else:
+                return Response(
+                    ALREADY_STOPPED_HTML,
+                    status=200,
+                    content_type="text/html",
+                )
         elif command == "start":
             if app_id in started_app_ids:
                 return Response(


### PR DESCRIPTION
## Summary
- avoid KeyError when stopping cron that's not running
- add new HTML message for the already stopped case

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68550415996c832abdc4fed1b94a3eab