### PR TITLE
Add step support to cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Cron needs a connection without timeout. That's why it doesn't work on https://c
 ## Cron Format
 
 The order is "seconds minutes hours days months weekdays".
-At the moment, only wildcards and lists are supported.
-For example, "0,15,30,45 * * * * *" will trigger the workflow every fifteen seconds; at XX:XX:00, XX:XX:15, XX:XX:30 and XX:XX:45 to be more specific.
+Wildcards, lists, and step values like `*/5` are supported.
+For example, `0,15,30,45 * * * * *` will trigger the workflow every fifteen seconds.
+`0 */5 * * * *` runs every five minutes.
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- support step (*/n) in cron string parsing
- document step value usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68551900ae28832a9fddfdd875426a4d